### PR TITLE
Add metadata.countries

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -280,13 +280,16 @@ class Build {
                 // languageData contains ALL territories where a language is
                 // spoken, so we will cross-reference with the territoryInfo
                 // to only find offical languages
-                languages[variant]["_territories"].forEach(trty => {
-                    const vrnt = territories[trty].languagePopulation[variant];
-                    // official or official_regional language if defined
-                    if(vrnt["_officialStatus"]) {
-                        official.push(trty);
-                    }
-                });
+                if(languages[variant]["_territories"]) {
+                    languages[variant]["_territories"].forEach(trty => {
+                        const vrnt =
+                            territories[trty].languagePopulation[variant];
+                        // official or official_regional language if defined
+                        if(vrnt["_officialStatus"]) {
+                            official.push(trty);
+                        }
+                    });
+                }
                 if(meta.official && Array.isArray(meta.official)) {
                     meta.official.concat(official);
                 } else {

--- a/build/build.js
+++ b/build/build.js
@@ -10,11 +10,8 @@ const fs = require("fs"), // file system
     del = require("del"), // delete files using patterns
     stripJsonComments = require("strip-json-comments"), // remove JSON comments
     Ajv = require("ajv"), // json schema validation
-
-    // Official language references
-    // unicode-cldr/cldr-core/master/supplemental/languageData.json
+    // official language references
     officialLang = require("cldr-data/supplemental/languageData"),
-    // unicode-cldr/cldr-core/master/supplemental/territoryInfo.json
     territoryInfo = require("cldr-data/supplemental/territoryInfo");
 
 /**

--- a/build/build.js
+++ b/build/build.js
@@ -11,7 +11,7 @@ const fs = require("fs"), // file system
     stripJsonComments = require("strip-json-comments"), // remove JSON comments
     Ajv = require("ajv"), // json schema validation
     // official language references
-    officialLang = require("cldr-data/supplemental/languageData"),
+    languageData = require("cldr-data/supplemental/languageData"),
     territoryInfo = require("cldr-data/supplemental/territoryInfo");
 
 /**
@@ -268,26 +268,26 @@ class Build {
      */
     addOfficialLang(json) {
         let clone = JSON.parse(JSON.stringify(json));
-        const languages = officialLang.supplemental.languageData,
+        const languages = languageData.supplemental.languageData,
             territories = territoryInfo.supplemental.territoryInfo;
         Object.keys(json).forEach(lang => {
             Object.keys(json[lang]).forEach(variant => {
                 const meta = clone[lang][variant].metadata;
-                let official = [];
+                let countries = [];
                 // languageData contains ALL territories where a language is
                 // spoken, so we will cross-reference with the territoryInfo
                 // to only find offical languages
                 if(languages[variant]["_territories"]) {
-                    languages[variant]["_territories"].forEach(trty => {
+                    languages[variant]["_territories"].forEach(territory => {
                         const vrnt =
-                            territories[trty].languagePopulation[variant];
+                            territories[territory].languagePopulation[variant];
                         // official or official_regional language if defined
                         if(vrnt["_officialStatus"]) {
-                            official.push(trty);
+                            countries.push(territory);
                         }
                     });
                 }
-                meta.official = official;
+                meta.countries = countries;
             });
         });
         return clone;

--- a/build/build.js
+++ b/build/build.js
@@ -287,11 +287,7 @@ class Build {
                         }
                     });
                 }
-                if(meta.official && Array.isArray(meta.official)) {
-                    meta.official.concat(official);
-                } else {
-                    meta.official = official;
-                }
+                meta.official = official;
             });
         });
         return clone;

--- a/build/schema.js
+++ b/build/schema.js
@@ -31,6 +31,14 @@
                     "type": "string",
                     "pattern": "^[A-Za-z]+$"
                 },
+                "official": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "pattern": "^[A-Z]{2}$"
+                    },
+                    "uniqueItems": true
+                },
                 "variant": {
                     "type": "string",
                     "pattern": "^[A-Za-z ]+$"

--- a/build/schema.js
+++ b/build/schema.js
@@ -31,14 +31,6 @@
                     "type": "string",
                     "pattern": "^[A-Za-z]+$"
                 },
-                "official": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "pattern": "^[A-Z]{2}$"
-                    },
-                    "uniqueItems": true
-                },
                 "variant": {
                     "type": "string",
                     "pattern": "^[A-Za-z ]+$"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "private": true,
   "devDependencies": {
     "ajv": "^4.8.2",
+    "cldr-data": "^30.0.1",
     "del": "^2.2.2",
     "glob": "^7.1.1",
     "node-fs-extra": "^0.8.1",

--- a/spec/README.md
+++ b/spec/README.md
@@ -70,7 +70,6 @@ Example structure for the German language file, which only contains lower case c
         "continent": "EU",
         "language": "German",
         "native": "Deutsch",
-        "official": [],
         "sources": [
             "https://en.wikipedia.org/wiki/German_orthography#Special_characters",
             "https://en.wikipedia.org/wiki/German_orthography#Sorting"
@@ -145,8 +144,6 @@ Optional
 Type: `Array`
 
 An array of territories where the given language is officially spoken. This entry is automatically added by the build script, with information obtained directly from the [languageData](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json) and [territoryInfo](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) provided by the unicode-CLDR database.
-
-Any entries in the `src` language file will be overwritten by this list.
 
 ###### metadata.sources
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -143,9 +143,9 @@ The associated language written in the native language.
 Optional
 Type: `Array`
 
-An array of countries where the given language is officially spoken. This entry is automatically added by the build script, with information obtained directly from the [languageData](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json) and [territoryInfo](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) provided by the unicode-CLDR database.
+An array of countries where the given language is officially spoken. This entry is automatically added by the build script, with language information obtained directly from Unicode's CLDR supplemental [languageData](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json) and cross-referenced with supplemental [territoryInfo](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) databases.
 
-The standard Unicode language identifiers follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) with some small differences; please see the [CLDR spec](http://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code) for more details. For a quick reference, use this [IETF-language-tags](http://data.okfn.org/data/core/language-codes) searchable table.
+The provided language tags are based on [IETF BCP 47](https://www.w3.org/International/articles/language-tags/) with some minor differences; please see the [CLDR spec](http://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code) for more details. For a quick reference, use this [IETF-language-tags](http://data.okfn.org/data/core/language-codes#resource-ietf-language-tags) searchable table.
 
 ###### metadata.sources
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -138,12 +138,14 @@ Type: `String`
 
 The associated language written in the native language.
 
-###### metadata.official
+###### metadata.countries
 
 Optional
 Type: `Array`
 
-An array of territories where the given language is officially spoken. This entry is automatically added by the build script, with information obtained directly from the [languageData](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json) and [territoryInfo](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) provided by the unicode-CLDR database.
+An array of countries where the given language is officially spoken. This entry is automatically added by the build script, with information obtained directly from the [languageData](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json) and [territoryInfo](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) provided by the unicode-CLDR database.
+
+The standard Unicode language identifiers follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) with some small differences; please see the [CLDR spec](http://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code) for more details.
 
 ###### metadata.sources
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -70,6 +70,7 @@ Example structure for the German language file, which only contains lower case c
         "continent": "EU",
         "language": "German",
         "native": "Deutsch",
+        "official": [],
         "sources": [
             "https://en.wikipedia.org/wiki/German_orthography#Special_characters",
             "https://en.wikipedia.org/wiki/German_orthography#Sorting"
@@ -137,6 +138,15 @@ Required
 Type: `String`
 
 The associated language written in the native language.
+
+###### metadata.official
+
+Optional
+Type: `Array`
+
+An array of territories where the given language is officially spoken. This entry is automatically added by the build script, with information obtained directly from the [languageData](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json) and [territoryInfo](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) provided by the unicode-CLDR database.
+
+Any entries added to the language `src` file will be included with the appended territory list.
 
 ###### metadata.sources
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -145,7 +145,7 @@ Type: `Array`
 
 An array of countries where the given language is officially spoken. This entry is automatically added by the build script, with information obtained directly from the [languageData](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json) and [territoryInfo](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) provided by the unicode-CLDR database.
 
-The standard Unicode language identifiers follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) with some small differences; please see the [CLDR spec](http://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code) for more details.
+The standard Unicode language identifiers follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) with some small differences; please see the [CLDR spec](http://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code) for more details. For a quick reference, use this [IETF-language-tags](http://data.okfn.org/data/core/language-codes) searchable table.
 
 ###### metadata.sources
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -138,15 +138,6 @@ Type: `String`
 
 The associated language written in the native language.
 
-###### metadata.countries
-
-Optional
-Type: `Array`
-
-An array of countries where the given language is officially spoken. This entry is automatically added by the build script, with language information obtained directly from Unicode's CLDR supplemental [languageData](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json) and cross-referenced with supplemental [territoryInfo](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) databases.
-
-The provided language tags are based on [IETF BCP 47](https://www.w3.org/International/articles/language-tags/) with some minor differences; please see the [CLDR spec](http://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code) for more details. For a quick reference, use this [IETF-language-tags](http://data.okfn.org/data/core/language-codes#resource-ietf-language-tags) searchable table.
-
 ###### metadata.sources
 
 Optional  
@@ -317,3 +308,14 @@ Required
 Type: `String`
 
 Contains a URL encoded value (e.g. `%C3%B6`) - see [percent encoding](https://en.wikipedia.org/wiki/Percent-encoding).
+
+#### 3.1.2 Other Automatically Generated Data
+
+##### metadata.countries
+
+Required  
+Type: `Array`
+
+An array of countries where the given language is officially spoken. This entry is automatically added by the build script, with language information obtained directly from Unicode's CLDR supplemental [languageData](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json) and cross-referenced with supplemental [territoryInfo](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) databases.
+
+The provided language tags are based on [IETF BCP 47](https://www.w3.org/International/articles/language-tags/) with some minor differences; please see the [CLDR spec](http://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code) for more details. For a quick reference, use this [IETF-language-tags](http://data.okfn.org/data/core/language-codes#resource-ietf-language-tags) searchable table ("territory" column).

--- a/spec/README.md
+++ b/spec/README.md
@@ -146,7 +146,7 @@ Type: `Array`
 
 An array of territories where the given language is officially spoken. This entry is automatically added by the build script, with information obtained directly from the [languageData](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json) and [territoryInfo](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) provided by the unicode-CLDR database.
 
-Any entries added to the language `src` file will be included with the appended territory list.
+Any entries in the `src` language file will be overwritten by this list.
 
 ###### metadata.sources
 


### PR DESCRIPTION
I added an `official` metadata entry which contains the territories where the given variant is officially spoken. I didn't call the entry `country` because the CLDR data lists the official languages under "territories".

* In the readme, I added `metadata.official` with the following comment, which I'm not sure is a good idea:
  > Any entries added to the language `src` file will be included with the appended territory list.

  It would be better to override the entry, but then I wasn't sure how to include the entry into the spec and `schema.js` file... either way, we will be scrutinizing every pull request.
* I included the CLDR-data npm module, but it installs the entire database (all 240+ Mb of JSON data) into the `node_modules` folder. I don't know if that is a big deal to you, but we could grab the JSON files directly from GitHub if you like that idea better:
  * https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json
  * https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json
    <p></p>
   The CLDR page showing all this data, in a nicely formatted table, can be found here: http://www.unicode.org/cldr/charts/latest/supplemental/language_territory_information.html, you'll find that territories with an `{O}` mean it's an "official" language, `{OD}` means it is a de facto official language, whereas `{OR}` means it is an "official regional" language. 
* The build script isn't including languages listed as the "official regional" in a territory right now. These entries are included as a language alt-secondary (e.g. see [`de-alt-secondary`](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/languageData.json#L1219-L1233). Which we could then find in the `territoryInfo` json the status entries for "official_regional" (e.g. see [`de` under `PL`](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json#L4659-L4680)). Do you think these territories should be included as well?