### PR TITLE
Use singular form for metadata properties

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -273,7 +273,7 @@ class Build {
         Object.keys(json).forEach(lang => {
             Object.keys(json[lang]).forEach(variant => {
                 const meta = clone[lang][variant].metadata;
-                let countries = [];
+                let country = [];
                 // languageData contains ALL territories where a language is
                 // spoken, so we will cross-reference with the territoryInfo
                 // to only find offical languages
@@ -283,11 +283,11 @@ class Build {
                             territories[territory].languagePopulation[variant];
                         // official or official_regional language if defined
                         if(vrnt["_officialStatus"]) {
-                            countries.push(territory);
+                            country.push(territory);
                         }
                     });
                 }
-                meta.countries = countries;
+                meta.country = country;
             });
         });
         return clone;

--- a/build/schema.js
+++ b/build/schema.js
@@ -16,16 +16,11 @@
                     "pattern": "^[A-Z]{1}[a-z]{3}$"
                 },
                 "continent": {
-                    "anyOf": [{
+                    "type": "array",
+                    "items": {
                         "type": "string",
                         "pattern": "^(AF|AS|EU|NA|SA|OC|AN)$"
-                    }, {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "pattern": "^(AF|AS|EU|NA|SA|OC|AN)$"
-                        }
-                    }]
+                    }
                 },
                 "language": {
                     "type": "string",

--- a/build/schema.js
+++ b/build/schema.js
@@ -34,7 +34,7 @@
                     "type": "string",
                     "pattern": "^[\\S]+$"
                 },
-                "sources": {
+                "source": {
                     "type": "array",
                     "items": {
                         "type": "string",

--- a/build/schema.js
+++ b/build/schema.js
@@ -28,7 +28,7 @@
                 },
                 "variant": {
                     "type": "string",
-                    "pattern": "^[A-Za-z ]+$"
+                    "pattern": "^[A-Za-z ,\\-\\(\\)\\'\\.]+$"
                 },
                 "native": {
                     "type": "string",

--- a/spec/README.md
+++ b/spec/README.md
@@ -76,7 +76,7 @@ Example structure for the German language source file, which only contains lower
         ],
         "language": "German",
         "native": "Deutsch",
-        "sources": [
+        "source": [
             "https://en.wikipedia.org/wiki/German_orthography#Special_characters"
         ]
     },
@@ -143,7 +143,7 @@ Type: `String`
 
 The associated language written in the native language.
 
-###### metadata.sources
+###### metadata.source
 
 Optional  
 Type: `Array`

--- a/spec/README.md
+++ b/spec/README.md
@@ -52,9 +52,13 @@ src/
 
 - As there might be multiple files for a language, each language has its own folder.
 - The language files in this folder will be in a `.js` format to allow comments and to make sure text editors allow formatting them. The containing source is JSON though.
-- Folder and file names must be according to [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
-- Each language variant has its own file. If the variants (e.g. `de_DE`, `de_AT`, `de_CH`) don't have any differences, only one file must be added.
-- When creating a language variant file all mappings need to be created (redundant) – not incrementally.
+- Folder and file names must be according to [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for the root language.
+- Each language variant has its own file:
+  - If the variants (e.g. `de-DE`, `de-AT`, `de-CH`) don't have any differences from the root language, only one root file must be added.
+  - When creating a language variant file all mappings need to be created (redundant) – not incrementally.
+  - Any variant file will be contained within the root language folder.
+  - The variant file is named according to [IETF language tag](https://www.w3.org/International/articles/language-tags/) extended language (`extlang`) subtag. So, _if_ a `de_AT` was necessary, then the file would be named `at.js`; by the extended language subtag and in all lower-case.
+  - See [this table](http://data.okfn.org/data/core/language-codes#resource-ietf-language-tags) for a quick reference of available IETF language tags.
 - Changes should only be done within the source files.
 
 Files within the `src/` folder are called **language files**.

--- a/spec/README.md
+++ b/spec/README.md
@@ -85,10 +85,10 @@ src/
 - The language files in this folder will be in a `.js` format to allow comments and to make sure text editors allow formatting them. The containing source is JSON though.
 - Folder and file names must be according to [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for the root language.
 - Each language variant has its own file:
-  - If the variants (e.g. `de-DE`, `de-AT`, `de-CH`) don't have any differences from the root language, only one root file must be added.
+  - If the variants (e.g. `de-DE`, `de-AT`, `de-CH`) don't have any differences from the root language, then only the root file is necessary.
   - When creating a language variant file all mappings need to be created (redundant) – not incrementally.
   - Any variant file will be contained within the root language folder.
-  - The variant file is named according to [IETF language tag](https://www.w3.org/International/articles/language-tags/) extended language (`extlang`) subtag. So, _if_ a `de_AT` was necessary, then the file would be named `at.js`; by the extended language subtag and in all lower-case.
+  - The variant file will be named according to [IETF language tag](https://www.w3.org/International/articles/language-tags/) extended language (`extlang`) subtag. So, _if_ a `de_AT` would be necessary, then the file would be named `at.js`; by the extended language subtag and in all lower-case.
   - See [this table](http://data.okfn.org/data/core/language-codes#resource-ietf-language-tags) for a quick reference of available IETF language tags.
 - Changes should only be done within the source files.
 
@@ -151,7 +151,7 @@ An alphabet code based on [ISO 15924](https://en.wikipedia.org/wiki/ISO_15924) t
 Required  
 Type: `Array`
 
-A array of continent codes based on [ISO-3166](https://en.wikipedia.org/wiki/List_of_sovereign_states_and_dependent_territories_by_continent_%28data_file%29) that specifies the associated continent.
+An array of continent codes based on [ISO-3166](https://en.wikipedia.org/wiki/List_of_sovereign_states_and_dependent_territories_by_continent_%28data_file%29) that specifies the associated continent.
 
 ###### metadata.language
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -316,7 +316,7 @@ Contains a URL encoded value (e.g. `%C3%B6`) - see [percent encoding](https://en
 
 #### 3.1.2 Other Automatically Generated Data
 
-##### metadata.countries
+##### metadata.country
 
 Required  
 Type: `Array`

--- a/spec/README.md
+++ b/spec/README.md
@@ -134,7 +134,7 @@ The associated language written in English.
 Optional  
 Type: `String`
 
-The associated language variant written in English, if applicable. For example, if the [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code is `de_AT`, this entry would include the full name of the variant country, `Austria` for the `AT` variant.
+The associated language variant written in English, if applicable. For example, if the [IETF language tag](https://www.w3.org/International/articles/language-tags/) was `de_AT`, this entry would include the full name of the variant country, `Austria` for the `AT` variant.
 
 ###### metadata.native
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -61,18 +61,19 @@ Files within the `src/` folder are called **language files**.
 
 ##### 2.1.2.1 Language File Specification
 
-Example structure for the German language file, which only contains lower case characters for brevity:
+Example structure for the German language source file, which only contains lower case characters for brevity:
 
 ```javascript
 {
     "metadata": {
         "alphabet": "Latn",
-        "continent": "EU",
+        "continent": [
+            "EU"
+        ],
         "language": "German",
         "native": "Deutsch",
         "sources": [
-            "https://en.wikipedia.org/wiki/German_orthography#Special_characters",
-            "https://en.wikipedia.org/wiki/German_orthography#Sorting"
+            "https://en.wikipedia.org/wiki/German_orthography#Special_characters"
         ]
     },
     "data": {
@@ -113,9 +114,9 @@ An alphabet code based on [ISO 15924](https://en.wikipedia.org/wiki/ISO_15924) t
 ###### metadata.continent
 
 Required  
-Type: `String` or `Array` of `String`
+Type: `Array`
 
-A continent code based on [ISO-3166](https://en.wikipedia.org/wiki/List_of_sovereign_states_and_dependent_territories_by_continent_%28data_file%29) that specifies the associated continent.
+A array of continent codes based on [ISO-3166](https://en.wikipedia.org/wiki/List_of_sovereign_states_and_dependent_territories_by_continent_%28data_file%29) that specifies the associated continent.
 
 ###### metadata.language
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -2,6 +2,37 @@
 
 > File specification for the diacritics database
 
+## Table of Contents
+
+- [1. What Information Must Be Collected](#1-what-information-must-be-collected)
+- [2. Master Branch](#2-master-branch)
+  - [2.1 Project Structure](#21-project-structure)
+  - [2.1.1. `spec/` Folder](#211-spec-folder)
+  - [2.1.2. `src/` Folder](#212-src-folder)
+  - [2.1.2.1. Language File Specification](#2121-language-file-specification)
+    - [metadata.alphabet](#metadataalphabet)
+    - [metadata.continent](#metadatacontinent)
+    - [metadata.language](#metadatalanguage)
+    - [metadata.variant](#metadatavariant)
+    - [metadata.native](#metadatanative)
+    - [metadata.source](#metadatasource)
+    - [data](#data)
+    - [data.{character}.mapping](#datacharactermapping)
+    - [data.{character}.mapping.base](#datacharactermappingbase)
+    - [data.{character}.mapping.decompose](#datacharactermappingdecompose)
+- [3. Dist Branch](#3-dist-branch)
+  - [3.1. diacritics.json](#31-diacriticsjson)
+  - [3.1.1. Visual Equivalents](#311-visual-equivalents)
+    - [equivalents](#equivalents)
+    - [equivalents[index].raw](#equivalentsindexraw)
+    - [equivalents[index].unicode](#equivalentsindexunicode)
+    - [equivalents[index].html_decimal](#equivalentsindexhtml_decimal)
+    - [equivalents[index].html_hex](#equivalentsindexhtml_hex)
+    - [equivalents[index].html_entity](#equivalentsindexhtml_entity)
+    - [equivalents[index].encoded_uri](#equivalentsindexencoded_uri)
+  - [3.1.2. Other Automatically Generated Data](#312-other-automatically-generated-data)
+    - [metadata.country](#metadatacountry)
+
 ## 1. What Information Must Be Collected?
 
 Since there's no trustworthy and complete source, it's necessary to collect all diacritics, ligatures and symbols mapping information manually. It's also necessary to collect meta information for each language such as links to sources documenting the characters.

--- a/src/de/de.js
+++ b/src/de/de.js
@@ -1,7 +1,9 @@
 {
     "metadata": {
         "alphabet": "Latn",
-        "continent": "EU",
+        "continent": [
+            "EU"
+        ],
         "language": "German",
         "native": "Deutsch",
         "sources": [

--- a/src/de/de.js
+++ b/src/de/de.js
@@ -6,7 +6,7 @@
         ],
         "language": "German",
         "native": "Deutsch",
-        "sources": [
+        "source": [
             "https://en.wikipedia.org/wiki/German_orthography#Special_characters"
         ]
     },

--- a/src/es/es.js
+++ b/src/es/es.js
@@ -4,7 +4,7 @@
         "continent": ["NA", "SA", "EU", "OC", "AF", "AN"],
         "language": "Spanish",
         "native": "Español",
-        "sources": [
+        "source": [
             "https://en.wikipedia.org/wiki/Spanish_orthography#Keyboard_requirements",
             // Spanish is the official or national language in Spain (EU),
             // Equatorial Guinea (AF), and 19 countries in the Americas...


### PR DESCRIPTION
I made a few updates to the spec & database:

- Changed `continent` to only allow an `array` instead of both a string and array to make accessing the values consistent
- Updated the wording on how to name a variant file. It now explicitly states that the `extlang` subtag of an [IETF language tag](https://www.w3.org/International/articles/language-tags/) should be used to name the variant file.
- Renamed `sources` to `source` to be consistent.
- Renamed `countries` to `country` to be consistent.

It doesn't look like the API will need to be modified for these changes.